### PR TITLE
Making log_prefix required

### DIFF
--- a/lib/fluent/plugin/in_cloudfront_log.rb
+++ b/lib/fluent/plugin/in_cloudfront_log.rb
@@ -24,6 +24,7 @@ class Fluent::Cloudfront_LogInput < Fluent::Input
     super
 
     raise Fluent::ConfigError.new unless @log_bucket
+    raise Fluent::ConfigError.new unless @log_prefix
     raise Fluent::ConfigError.new unless @region
 
     @moved_log_bucket = @log_bucket unless @moved_log_bucket


### PR DESCRIPTION
If you don't specify a log_prefix the td-agent will fail to start with: 

2016-05-10 18:47:52 +0000 [error]: dry run failed: no implicit conversion of nil into String
