### PR TITLE
without this it gives an error

### DIFF
--- a/lib/fluent/plugin/in_cloudfront_log.rb
+++ b/lib/fluent/plugin/in_cloudfront_log.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 class Fluent::Cloudfront_LogInput < Fluent::Input
   Fluent::Plugin.register_input('cloudfront_log', self)
 


### PR DESCRIPTION
        21: from /usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `requir$
'
        20: from /usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `requir$
'
        19: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/command/fluentd.rb:314:in `$
top (required)>'
        18: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/supervisor.rb:504:in `run_s$
pervisor'
        17: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/supervisor.rb:599:in `super$
ise'
        16: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/supervisor.rb:581:in `dry_r$
n'
        15: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/supervisor.rb:804:in `run_c$
nfigure'
        14: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/engine.rb:96:in `run_config$
re'
        13: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/engine.rb:131:in `configure$
        12: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/root_agent.rb:156:in `confi$
ure'
        11: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/root_agent.rb:156:in `each'
        10: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/root_agent.rb:160:in `block
in configure'
         9: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/root_agent.rb:315:in `add_s$
urce'
         8: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/plugin.rb:100:in `new_input$
         7: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/plugin.rb:146:in `new_impl'
         6: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/registry.rb:44:in `lookup'
         5: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/registry.rb:99:in `search'
         4: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/registry.rb:99:in `each'
         3: from /usr/local/bundle/gems/fluentd-1.7.1/lib/fluent/registry.rb:102:in `block i$
 search'
         2: from /usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `requir$
'
         1: from /usr/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require
'
/usr/local/bundle/gems/fluent-plugin-cloudfront-log-0.0.5/lib/fluent/plugin/in_cloudfront_log
.rb:1:in `<top (required)>': uninitialized constant Fluent::Input (NameError)